### PR TITLE
Update GitHub action config

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -47,10 +47,10 @@ jobs:
           perl-version: '5.30'
       - name: Install Nmake
         if: matrix.env.name == 'win'
-        uses: seanmiddleditch/gha-setup-vsdevenv@v1
+        uses: seanmiddleditch/gha-setup-vsdevenv@v3
       - name: Install NASM
         if: matrix.env.name == 'win'
-        uses: ilammy/setup-nasm@v1.0.0
+        uses: ilammy/setup-nasm@v1.2.0
       - name: Build OpenSSL (linux)
         if: matrix.env.name == 'linux'
         run: |
@@ -70,13 +70,13 @@ jobs:
           perl Configure VC-WIN64A
           nmake
       - name: Install Ninja
-        uses: seanmiddleditch/gha-setup-ninja@v1
+        uses: seanmiddleditch/gha-setup-ninja@v3
         with:
           version: 1.9.0
           platform: ${{ matrix.env.ninja_platform }}
           destination: ninja
       - name: Install Qt
-        uses: jurplel/install-qt-action@v2.2.0
+        uses: jurplel/install-qt-action@v2.13.0
         timeout-minutes: 10
         with:
           version: 5.12.5

--- a/.github/workflows/build-stage.yml
+++ b/.github/workflows/build-stage.yml
@@ -48,10 +48,10 @@ jobs:
           perl-version: '5.30'
       - name: Install Nmake
         if: matrix.env.name == 'win'
-        uses: seanmiddleditch/gha-setup-vsdevenv@v1
+        uses: seanmiddleditch/gha-setup-vsdevenv@v3
       - name: Install NASM
         if: matrix.env.name == 'win'
-        uses: ilammy/setup-nasm@v1.0.0
+        uses: ilammy/setup-nasm@v1.2.0
       - name: Build OpenSSL (linux)
         if: matrix.env.name == 'linux'
         run: |
@@ -71,13 +71,13 @@ jobs:
           perl Configure VC-WIN64A
           nmake
       - name: Install Ninja
-        uses: seanmiddleditch/gha-setup-ninja@v1
+        uses: seanmiddleditch/gha-setup-ninja@v3
         with:
           version: 1.9.0
           platform: ${{ matrix.env.ninja_platform }}
           destination: ninja
       - name: Install Qt
-        uses: jurplel/install-qt-action@v2.2.0
+        uses: jurplel/install-qt-action@v2.13.0
         timeout-minutes: 10
         with:
           version: 5.12.5


### PR DESCRIPTION
This change udpates some of the out of date github workflow action helpers to the latest versions to get past deprecation errors.

Based on https://github.com/gitahead/gitahead/pull/582.